### PR TITLE
Added permissions to control the different actions

### DIFF
--- a/code/extensions/SectionPageExtension.php
+++ b/code/extensions/SectionPageExtension.php
@@ -34,10 +34,15 @@ class SectionPageExtension extends DataExtension
      */
     function updateCMSFields(FieldList $fields)
     {
+        if (!Permission::check("VIEW_SECTIONS")) {
+            return $fields;
+        }
+
         $SectionGrid = GridFieldConfig_RelationEditor::create()
             ->removeComponentsByType('GridFieldAddNewButton')
             ->addComponent(new GridFieldAddNewMultiClass())
             ->addComponent(new GridFieldOrderableRows());
+
         $SectionGrid->getComponentByType('GridFieldAddExistingAutocompleter')
             ->setSearchFields(array('AdminTitle'))
             ->setResultsFormat('$AdminTitle');
@@ -50,6 +55,7 @@ class SectionPageExtension extends DataExtension
 
         # Limit sections based on type
         $LimitSectionTypes = Config::inst()->get($this->owner->ClassName, 'LimitSectionTypes');
+        // debug::dump($LimitSectionTypes);
         if ($LimitSectionTypes) {
             foreach ($LimitSectionTypes as $type => $value) {
                 if ($value == 0) {
@@ -75,6 +81,18 @@ class SectionPageExtension extends DataExtension
             $SectionGrid->removeComponentsByType('GridFieldAddNewButton');
             $SectionGrid->removeComponentsByType('GridFieldAddExistingAutocompleter');
             $SectionGrid->removeComponentsByType('GridFieldAddNewMultiClass');
+        }
+
+        if (!Permission::check("LINK_SECTIONS")) {
+            $SectionGrid->removeComponentsByType('GridFieldAddExistingAutocompleter');
+        }
+
+        if (!Permission::check("REORDER_SECTIONS")) {
+            $SectionGrid->removeComponentsByType('GridFieldOrderableRows');
+        }
+
+        if (!Permission::check("UNLINK_SECTIONS")) {
+            $SectionGrid->removeComponentsByType('GridFieldDeleteAction');
         }
 
         $fields->addFieldToTab(

--- a/code/models/Section.php
+++ b/code/models/Section.php
@@ -1,5 +1,5 @@
 <?php
-class Section extends DataObject
+class Section extends DataObject implements PermissionProvider
 {
     /**
      * Singular name for CMS
@@ -88,11 +88,57 @@ class Section extends DataObject
         'AdminTitle'
     );
 
+
+    /**
+     * Permissions
+     * @return array
+     */
+    public function providePermissions() {
+        return array(
+            "VIEW_SECTIONS" => array(
+                'name' => 'View any sections',
+                'help' => 'Allow users to view any sections on a page',
+                'category' => 'Sections',
+                'sort' => 88
+            ),
+            "CREATE_SECTIONS" => array(
+                'name' => 'Create sections',
+                'help' => 'Allow users to create new sections on pages',
+                'category' => 'Sections',
+                'sort' => 90
+            ),
+            "EDIT_SECTIONS" => array(
+                'name' => 'Edit sections',
+                'help' => 'Allow users to edit existing sections',
+                'category' => 'Sections',
+                'sort' => 92
+            ),
+            "DELETE_SECTIONS" => array(
+                'name' => 'Delete sections',
+                'help' => 'Allow users to delete sections from pages',
+                'category' => 'Sections',
+                'sort' => 94
+            ),
+            "LINK_SECTIONS" => array(
+                'name' => 'Link existing sections',
+                'help' => 'Allow users to link existing sections to a page',
+                'category' => 'Sections',
+                'sort' => 96
+            ),
+            "REORDER_SECTIONS" => array(
+                'name' => 'Change order of sections',
+                'help' => 'Allow users to change the order of existing sections on a page',
+                'category' => 'Sections',
+                'sort' => 100
+            )
+        );
+    }
+
     /**
      * Viewing Permissions
      */
     public function canView($member = null) {
-        return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
+        return Permission::check('VIEW_SECTIONS', 'any', $member);
     }
 
     /**
@@ -100,7 +146,7 @@ class Section extends DataObject
      * @return boolean
      */
     public function canEdit($member = null) {
-        return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
+        return Permission::check('EDIT_SECTIONS', 'any', $member);
     }
 
     /**
@@ -108,7 +154,7 @@ class Section extends DataObject
      * @return boolean
      */
     public function canDelete($member = null) {
-        return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
+        return Permission::check('DELETE_SECTIONS', 'any', $member);
     }
 
     /**
@@ -116,7 +162,7 @@ class Section extends DataObject
      * @return boolean
      */
     public function canCreate($member = null) {
-        return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
+        return Permission::check('CREATE_SECTIONS', 'any', $member);
     }
 
     public function getConfigStyles(){


### PR DESCRIPTION
Added permissions to control the different actions.

By default only ADMIN will have all the permissions.

It's best to setup a custom group and check the permission you want the user to have.

E.g. re-ordering of sections might not be great so this shouldn't be done by a content author.
